### PR TITLE
New data store schema

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -525,7 +525,12 @@ function Player:storeInventory(item, amount)
     for k, data in next, inv do
         if data[1] == item then
             found = true
-            inv[k] = {item, amount}
+            if not amount then
+                table.remove(inv, k)
+            else 
+                inv[k] = {item, amount}
+            end
+
             break
         end
     end

--- a/game.lua
+++ b/game.lua
@@ -358,7 +358,9 @@ end
 
 function Player:setTitle(newTitle)
     for id, title in next, titles do
-        if title == newTitle and self.titles[id] then
+        print(self.titles[id])
+        if title == newTitle and find(id, self.titles, true) then
+            print("found")
             self.title = newTitle
             self:updateStatsBar()
             dHandler:set(self.name, "title", id)

--- a/game.lua
+++ b/game.lua
@@ -1392,11 +1392,7 @@ function eventPopupAnswer(id, name, answer)
 end
 
 function eventChatCommand(name, msg)
-    --TODO; Remove this conditional
-    if msg == "save" then
-        print(dHandler:dumpPlayer(name))
-        system.savePlayerData(name, dHandler:dumpPlayer(name))
-    elseif string.sub(msg, 1, 7) == "company" then
+    if string.sub(msg, 1, 7) == "company" then
         displayCompany(string.sub(msg, 9), name)
     elseif string.sub(msg, 1, 7) == "profile" then
         displayProfile(string.sub(msg, 9), name)

--- a/game.lua
+++ b/game.lua
@@ -426,7 +426,7 @@ function Player:investTo(comName, amount, sharePurchase)
                 return
             end
                 companies[comName]:setShares(-amount / 100, true)
-            tfm.exec.chatMessage("<J>Bought shares from '" .. comName .. "'</J>", self.name)                
+            tfm.exec.chatMessage("<J>Bought shares from '" .. comName .. "'</J>", self.name)
         end
         companies[comName]:addShareHolder(self.name, amount)
         self:setMoney(-amount, true)
@@ -498,7 +498,7 @@ function Player:grabItem(item)
     else
         self.inventory[item] = self.inventory[item] + 1
     end
-    
+
     for id, value in next, items do
         if item == value then
             self:storeInventory(id, self.inventory[item])
@@ -529,7 +529,7 @@ function Player:storeInventory(item, amount)
             found = true
             if not amount then
                 table.remove(inv, k)
-            else 
+            else
                 inv[k] = {item, amount}
             end
 
@@ -819,7 +819,7 @@ function displayProfile(name, target)
     local p = players[name] or players[up] or players[up .. "#0000"] or players[target]
     if p then
         ui.addTextArea(900, closeButton ..
-        "<p align='center'><font size='15'><b><BV>" .. p:getName() .."</BV></b></font><br>« " .. p:getTitle() .. " »</p><br><b>Level:</b> " .. tostring(p:getLevel()) .. "<BL><font size='12'> [" .. tostring(p:getXP()) .. "XP / " .. tostring(calculateXP(p:getLevel() + 1)) .. "XP]</font></BL><br><b>Money:</b> $" .. formatNumber(p:getMoney()) .. "<br><br><b>Working as a</b> " .. p:getJob() .. 
+        "<p align='center'><font size='15'><b><BV>" .. p:getName() .."</BV></b></font><br>« " .. p:getTitle() .. " »</p><br><b>Level:</b> " .. tostring(p:getLevel()) .. "<BL><font size='12'> [" .. tostring(p:getXP()) .. "XP / " .. tostring(calculateXP(p:getLevel() + 1)) .. "XP]</font></BL><br><b>Money:</b> $" .. formatNumber(p:getMoney()) .. "<br><br><b>Working as a</b> " .. p:getJob() ..
         "<br><b>Learning</b>: " .. (p:getLearningCourse() == "" and "NA" or p:getLearningCourse())
         , target, 300, 100, 200, 140, nil, nil, 1, true)
     end
@@ -1000,7 +1000,7 @@ function getTopCompanies(upto)
         return e1[2] > e2[2]
     end)
 
-    if not upto then return temp end   
+    if not upto then return temp end
     local top = {}
     for i=1, upto, 1 do
         if temp[i] then
@@ -1147,7 +1147,7 @@ function eventNewPlayer(name)
     tfm.exec.respawnPlayer(name)
     if not players[name] then
         system.loadPlayerData(name)
-    else    
+    else
         setUI(name)
         players[name]:setJob("Cheese collector")
     end
@@ -1172,7 +1172,7 @@ function eventPlayerDataLoaded(name, data)
     for _, data in next, dHandler:get(name, "inventory") do
         inv[items[data[1]]] = data[2]
     end
-  
+
     players[name] = Player(name, {
         money = dHandler:get(name, "money"),
         title = titles[dHandler:get(name, "title")],
@@ -1289,7 +1289,7 @@ function eventTextAreaCallback(id, name, evt)
     elseif evt == "getLottery" then
         ui.addPopup(1000, 2, "<p align='center'>Please enter your choices (3 numbers between 0 and 100 and a letter) separated by spaces. <br><i>eg:15 20 30 B</i><br><br><b><i>Price: $20</i></b></p>", name, 300, 90, 200, true)
     elseif evt == "checkLotto" then
-        displayLotto(name)        
+        displayLotto(name)
     elseif evt:gmatch("%w+:%w+") then
         local type = split(evt, ":")[1]
         local val = split(evt, ":")[2]

--- a/game.lua
+++ b/game.lua
@@ -1167,34 +1167,12 @@ end
 function eventPlayerDataLoaded(name, data)
     print("Loaded player data (" .. name .. ")") --.. data)
     dHandler:newPlayer(name, data)
-    --[[local titles = {}
-    for _, title in next, dHandler:get(name, "titles") do
-        title = title:sub(2, #title - 1)
-        titles[title] = "« " .. title .. " »"
-    end]]
 
-    --[[local title = dHandler:get(name, "title")
-    for _, id in next, titles do
-        if id == title then title = titles[id] break end 
-    end]]
-
-    --[[local degrees = {}
-    for _, degree in next, dHandler:get(name, "degrees") do
-        degree = degree:sub(2, #degree - 1)
-        degrees[degree] = courses[degree]
-    end]]
-
-    --[[local inv = {}
-    for _, data in next, dHandler:get(name, "inventory") do
-        local n = data[1]:sub(2, #data[1] - 1)
-        inv[n] = data[2]
-    end]]
     local inv = {}
     for _, data in next, dHandler:get(name, "inventory") do
         inv[items[data[1]]] = data[2]
     end
-
-    
+  
     players[name] = Player(name, {
         money = dHandler:get(name, "money"),
         title = titles[dHandler:get(name, "title")],
@@ -1208,9 +1186,6 @@ function eventPlayerDataLoaded(name, data)
         degrees = dHandler:get(name, "degrees"),
         inventory = inv
     })
-    --dHandler:set(name, "titles", map(dHandler:get(name, "titles"), function(t) return t:sub(2, #t - 1)end))
-    --dHandler:set(name, "degrees", map(dHandler:get(name, "degrees"), function(d) return d:sub(2, #d - 1) end))
-    --players[name]:storeInventory()
     tempData[name] = {}
     setUI(name)
     players[name]:setJob("Cheese collector")

--- a/game.lua
+++ b/game.lua
@@ -156,6 +156,18 @@ local titles = {
     [8] = "Businessman"
 }
 
+local coursesHelper = {
+    [1] = "School",
+    [2] = "Junior Sports Club",
+    [3] = "High School",
+    [4] = "Cheese mining",
+    [5] = "Cheese trading",
+    [6] = "Cheese developing",
+    [7] = "Law",
+    [8] = "Cheese trading-II",
+    [9] = "Fullstack cheese developing"
+}
+
 
 local ab = {"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"}
 local latestLotto = {}
@@ -167,7 +179,7 @@ local dHandler = DataHandler.new("clicker", {
     title = {index = 2, type = "number", default = 1},
     xp =    {index = 3, type = "number", default = 1},
     level = {index = 4, type = "number", default = 1},
-    learning = {index = 5, type = "string", default = ""},
+    learning = {index = 5, type = "number", default = 0},
     learnProgress = {index = 6, type = "number", default = 0},
     eduLvl = {index = 7, type = "number", default = 1},
     eduStream = {index =  8, type = "string", default = ""},
@@ -352,16 +364,6 @@ function Player:addTitle(newTitle)
         dHandler:set(self.name, "titles", self.titles)
         tfm.exec.chatMessage("<D>Congratulations, " ..  self.name .. " achieved a new title\n« " .. titles[tid] .. " »</D>")
     end
-    --[[if not self.titles[newTitle] then
-        self.titles[newTitle] = "« " .. newTitle .. " »"
-        local titles = {}
-        for title, _ in next, self.titles do
-            table.insert(titles, title)
-        end
-        dHandler:set(self.name, "titles", titles)
-        titles = nil
-        tfm.exec.chatMessage("<D>Congratulations, " ..  self.name .. " achieved a new title\n" .. self.titles[newTitle] .. "</D>")
-    end]]
 end
 
 function Player:setCourse(course)
@@ -369,7 +371,7 @@ function Player:setCourse(course)
     self.learnProgress = 0
     self.eduLvl = course.level
     self.eduStream = course.stream
-    dHandler:set(self.name, "learning", self.learning)
+    dHandler:set(self.name, "learning", course.id)
     dHandler:set(self.name, "learnProgress", self.learnProgress)
     dHandler:set(self.name, "eduLvl", self.eduLvl)
     dHandler:set(self.name, "eduStream", self.eduStream)
@@ -441,7 +443,7 @@ function Player:learn()
                 self:addTitle("Dedicated Learner")
             end
         end
-        dHandler:set(self.name, "learning", self.learning)
+        dHandler:set(self.name, "learning", courses[self.learning] and courses[self.learning].id or 0)
         dHandler:set(self.name, "learnProgress", self.learnProgress)
         dHandler:set(self.name, "eduLvl", self.eduLvl)
         dHandler:set(self.name, "eduStream", self.eduStream)
@@ -1018,8 +1020,9 @@ function HealthPack(_name, _price, _regainVal, _adding, _desc)
     }
 end
 
-function Course(_name, _fee, _lessons, _level, _stream)
+function Course(_id, _name, _fee, _lessons, _level, _stream)
     return {
+        id = _id,
         name = _name,
         fee = _fee,
         lessons = _lessons,
@@ -1147,7 +1150,7 @@ function eventPlayerDataLoaded(name, data)
         titles = dHandler:get(name, "titles"),
         xp = dHandler:get(name, "xp"),
         level = dHandler:get(name, "level"),
-        learning = dHandler:get(name, "learning"),
+        learning = coursesHelper[dHandler:get(name, "learning")],
         learnProgress = dHandler:get(name, "learnProgress"),
         eduLvl = dHandler:get(name, "eduLvl"),
         eduStream = dHandler:get(name, "eduStream"),
@@ -1453,15 +1456,15 @@ table.insert(healthPacks, HealthPack("Vito`s Lasagne", 2000, 0.8, true, "World's
 table.insert(healthPacks, HealthPack("Ambulance!", 2500, 1, false, "Restores your health back! (Powered by Shaman!)"))
 
 --creating and storing Course tables
-courses["School"] = Course("School", 20, 2, 1, "")
-courses["Junior Sports Club"] = Course("Junior Sports Club", 10, 4, 2, "")
-courses["High School"] = Course("High School", 1000, 20, 3, "")
-courses["Cheese mining"] = Course("Cheese mining", 3000, 30, 4, "admin")
-courses["Cheese trading"] = Course("Cheese trading", 5000, 30, 4, "bs")
-courses["Cheese developing"] = Course("Cheese developing", 5500, 50, 4, "it")
-courses["Law"] = Course("Law", 100000, 80, 5, "admin")
-courses["Cheese trading-II"] = Course("Cheese trading-II", 200000, 75, 5, "bs")
-courses["Fullstack cheese developing"] = Course("Fullstack cheese developing", 150000, 70, 5, "it")
+courses["School"] = Course(1, "School", 20, 2, 1, "")
+courses["Junior Sports Club"] = Course(2, "Junior Sports Club", 10, 4, 2, "")
+courses["High School"] = Course(3, "High School", 1000, 20, 3, "")
+courses["Cheese mining"] = Course(4, "Cheese mining", 3000, 30, 4, "admin")
+courses["Cheese trading"] = Course(5, "Cheese trading", 5000, 30, 4, "bs")
+courses["Cheese developing"] = Course(6, "Cheese developing", 5500, 50, 4, "it")
+courses["Law"] = Course(7, "Law", 100000, 80, 5, "admin")
+courses["Cheese trading-II"] = Course(8, "Cheese trading-II", 200000, 75, 5, "bs")
+courses["Fullstack cheese developing"] = Course(9, "Fullstack cheese developing", 150000, 70, 5, "it")
 --creating and stofing Job tables
 jobs["Cheese collector"] = Job("Cheese collector", 10, 0.05, 1, nil, "shaman", "Atelier801")
 jobs["Junior miner"] = Job("Junior miner", 25, 0.1, 3, nil, "shaman", "Atelier801")


### PR DESCRIPTION
The previous schema was lengthy and some times exceeded the character limit of 2000. Here's how it looked like before

```js
clicker={2.7881026E22,"Worker",3633,37,"",70,6,"it",{"School","Cheese developing","Fullstack cheese developing","Junior Sports Club","High School"},{{"Ambulance!",25}},{"Worker","Businessman","Degree Holder","Investor","Getting Experience","Dedicated Learner","Little Learner"}}
```

The `string` values is the most obvious reason for this exceeding character limit. 

This PR is intended to replace those `string` values with numbers, and use other methods to reduce the characters
For example, like below (it's also decided to rename `clicker` with `merchant`)
```js
merchant={12345,3,5343,12,5,4,"it",{1,2,3,4,5},{{1,25},{2,4},{1,2,3,4,5}
```

From the above example it's obvious that we can save more with this method

closes #76 